### PR TITLE
Adds prop type support to eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,7 @@ export default defineConfig([
 			'react/jsx-uses-react': 'error',
 			'react/jsx-uses-vars': 'error',
 			'react-hooks/set-state-in-effect': 'off',
+			'react/prop-types': 'off',
 			'no-use-before-define': [
 				'warn',
 				{
@@ -52,6 +53,14 @@ export default defineConfig([
 		},
 		settings: {
 			react: { version: 'detect' },
+		},
+	},
+	{
+		files: ['**/*.test.{js,jsx}'],
+		languageOptions: {
+			globals: {
+				...globals.jest,
+			},
 		},
 	},
 ])


### PR DESCRIPTION
Adds prop type support to eslint which I noticed wasn't included when I was migrating and running lint.